### PR TITLE
feat: Provide an option to disable all default key mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,19 @@ the plugin will try to keep it at same five lines, but the lines will be shorter
 
 The default configuration options are specified and documented [here](https://github.com/ovk/endec.nvim/blob/main/lua/endec/config.lua).
 
-By default, all key mappings for all encodings are enabled, but any default mapping can be disabled by setting the corresponding mapping to and empty string
+By default, all key mappings for all encodings are enabled, but any default mapping can be disabled by setting the corresponding mapping to an empty string
 (for example - `encode_url_inplace = ""`).
+
+To disable *all* default key mappings set `keymaps.defaults = false` in the config.
+Individual mappings can then be specified as desired, for example:
+
+```lua
+keymaps = {
+    defaults = false,
+
+    encode_base64_inplace = "gB"
+}
+```
 
 ### Default Key Mappings
 

--- a/lua/endec/config.lua
+++ b/lua/endec/config.lua
@@ -4,6 +4,9 @@ local config = {
     -- Key mappings.
     -- Set any mapping to empty string to disable it.
     keymaps = {
+        -- Set to `false` to disable all default mappings.
+        defaults = true,
+
         -- Decode Base64 in-place (normal mode)
         decode_base64_inplace = "gyb",
 
@@ -122,6 +125,10 @@ end
 --- @param cfg table
 M.setup = function(cfg)
     check_unknown_keys(cfg)
+
+    if cfg.keymaps ~= nil and cfg.keymaps.defaults == false then
+        config.keymaps = {}
+    end
 
     local new = vim.tbl_deep_extend("force", {}, config, cfg or {})
 

--- a/lua/endec/keymap.lua
+++ b/lua/endec/keymap.lua
@@ -109,7 +109,7 @@ M.setup = function()
     }
 
     for _, mapping in ipairs(keymaps) do
-        if #mapping.lhs > 0 then
+        if mapping.lhs ~= nil and #mapping.lhs > 0 then
             vim.keymap.set("n", mapping.lhs, mapping.normal, { desc = mapping.name })
             vim.keymap.set("x", mapping.lhs, mapping.visual, { desc = mapping.name, silent = true })
         end


### PR DESCRIPTION
Small feature to address #3.

To disable *all* default key mappings set `keymaps.defaults = false` in the config.
Individual mappings can then be specified as desired, for example:

```lua
keymaps = {
    defaults = false,

    encode_base64_inplace = "gB"
}
```